### PR TITLE
Fixes for discovery key hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ module.exports = class Corestore extends EventEmitter {
       }
     })
     for (const core of this.cores.values()) {
-      core.replicate(stream)
+      if (core.opened) core.replicate(stream) // If the core is not opened, it will be replicated in preload.
     }
     const streamRecord = { stream, isExternal }
     this._replicationStreams.push(streamRecord)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { EventEmitter } = require('events')
+const safetyCatch = require('safety-catch')
 const crypto = require('hypercore-crypto')
 const sodium = require('sodium-universal')
 const Hypercore = require('hypercore')
@@ -37,11 +38,11 @@ module.exports = class Corestore extends EventEmitter {
   }
 
   async _generateKeys (opts) {
-    if (opts.discoveryKey) {
+    if (opts._discoveryKey) {
       return {
         keyPair: null,
         sign: null,
-        discoveryKey: opts.discoveryKey
+        discoveryKey: opts._discoveryKey
       }
     }
     if (!opts.name) {
@@ -94,10 +95,15 @@ module.exports = class Corestore extends EventEmitter {
 
     while (this.cores.has(id)) {
       const existing = this.cores.get(id)
-      if (existing) {
-        if (!existing.closing) return { from: existing, keyPair, sign }
+      if (existing.closing) {
         await existing.close()
+        continue
       }
+      if (!existing.opened) {
+        await existing.ready().catch(safetyCatch)
+        continue // If ready throws, the erroring core will be evicted now
+      }
+      return { from: existing, keyPair, sign }
     }
 
     const userData = {}
@@ -110,22 +116,28 @@ module.exports = class Corestore extends EventEmitter {
 
     const storageRoot = [CORES_DIR, id.slice(0, 2), id.slice(2, 4), id].join('/')
     const core = new Hypercore(p => this.storage(storageRoot + '/' + p), {
+      _preready: this._preready.bind(this),
       autoClose: true,
       encryptionKey: opts.encryptionKey || null,
-      keyPair: {
-        publicKey: keyPair.publicKey,
-        secretKey: null
-      },
       userData,
       sign: null,
-      _preready: this._preready.bind(this),
-      createIfMissing: !!opts.keyPair
+      createIfMissing: !opts._discoveryKey,
+      keyPair: keyPair && keyPair.publicKey
+        ? {
+            publicKey: keyPair.publicKey,
+            secretKey: null
+          }
+        : null
     })
 
     this.cores.set(id, core)
-    for (const { stream } of this._replicationStreams) {
-      core.replicate(stream)
-    }
+    core.ready().then(() => {
+      for (const { stream } of this._replicationStreams) {
+        core.replicate(stream)
+      }
+    }, () => {
+      this.cores.delete(id)
+    })
     core.once('close', () => {
       this.cores.delete(id)
     })
@@ -145,18 +157,21 @@ module.exports = class Corestore extends EventEmitter {
 
   replicate (isInitiator, opts) {
     const isExternal = isStream(isInitiator) || !!(opts && opts.stream)
-    const stream = Hypercore.createProtocolStream(isInitiator, opts)
+    const stream = Hypercore.createProtocolStream(isInitiator, {
+      ...opts,
+      ondiscoverykey: async discoveryKey => {
+        try {
+          const core = this.get({ _discoveryKey: discoveryKey })
+          await core.ready()
+          core.replicate(stream)
+        } catch (err) {
+          safetyCatch(err)
+        }
+      }
+    })
     for (const core of this.cores.values()) {
       core.replicate(stream)
     }
-    stream.on('discovery-key', discoveryKey => {
-      const core = this.get({ discoveryKey })
-      core.ready().then(() => {
-        core.replicate(stream)
-      }, () => {
-        stream.close(discoveryKey)
-      })
-    })
     const streamRecord = { stream, isExternal }
     this._replicationStreams.push(streamRecord)
     stream.once('close', () => {
@@ -216,8 +231,7 @@ function validateGetOptions (opts) {
   if (opts.name && opts.secretKey) throw new Error('Cannot provide both a name and a secret key')
   if (opts.publicKey && !Buffer.isBuffer(opts.publicKey)) throw new Error('publicKey option must be a Buffer')
   if (opts.secretKey && !Buffer.isBuffer(opts.secretKey)) throw new Error('secretKey option must be a Buffer')
-  if (opts.discoveryKey && !Buffer.isBuffer(opts.discoveryKey)) throw new Error('discoveryKey option must be a Buffer')
-  if (!opts.name && !opts.publicKey) throw new Error('Must provide either a name or a publicKey')
+  if (!opts._discoveryKey && (!opts.name && !opts.publicKey)) throw new Error('Must provide either a name or a publicKey')
   return opts
 }
 

--- a/index.js
+++ b/index.js
@@ -159,14 +159,9 @@ module.exports = class Corestore extends EventEmitter {
     const isExternal = isStream(isInitiator) || !!(opts && opts.stream)
     const stream = Hypercore.createProtocolStream(isInitiator, {
       ...opts,
-      ondiscoverykey: async discoveryKey => {
-        try {
-          const core = this.get({ _discoveryKey: discoveryKey })
-          await core.ready()
-          core.replicate(stream)
-        } catch (err) {
-          safetyCatch(err)
-        }
+      ondiscoverykey: discoveryKey => {
+        const core = this.get({ _discoveryKey: discoveryKey })
+        return core.ready().catch(safetyCatch)
       }
     })
     for (const core of this.cores.values()) {

--- a/index.js
+++ b/index.js
@@ -95,15 +95,12 @@ module.exports = class Corestore extends EventEmitter {
 
     while (this.cores.has(id)) {
       const existing = this.cores.get(id)
-      if (existing.closing) {
-        await existing.close()
-        continue
-      }
+      if (existing.opened && !existing.closing) return { from: existing, keyPair, sign }
       if (!existing.opened) {
         await existing.ready().catch(safetyCatch)
-        continue // If ready throws, the erroring core will be evicted now
+      } else if (existing.closing) {
+        await existing.close()
       }
-      return { from: existing, keyPair, sign }
     }
 
     const userData = {}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "derive-key": "^1.0.1",
     "hypercore": "next",
     "hypercore-crypto": "^2.3.0",
+    "safety-catch": "^1.0.1",
     "sodium-universal": "^3.0.4"
   }
 }


### PR DESCRIPTION
Corestore hasn't been properly handling cores that are created after replication has begun. Hypercore 10 removed the `discovery-key` event and replaced it with an `ondiscoverykey` hook, so this PR accounts for that.

Testing this hook revealed a few caching + error handling issues that surface when one side lacks the replication capability:
1. In test scenarios, `ondiscoverykey` might be called immediately before the core is created with the correct capability (if replication has already started). The `preload` behavior needed to be updated to handle cores that were created without the correct capability, and then fail during `ready`.
2. If a core that lacks the capability is replicated into the top-level stream (`core.replicate(stream)`), its ready failure will trigger a top-level stream failure. This is solved by waiting for `ready` before replicating the core in `preload`, and only replicating opened cores in `replicate`.

This PR depends on https://github.com/hypercore-protocol/hypercore-next/pull/74