### PR TITLE
fix(userData): use namespace from userData to load cores

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ module.exports = class Corestore extends EventEmitter {
     return { from: core, keyPair, auth }
   }
 
-  async createKeyPair (name) {
+  async createKeyPair (name, namespace = this._namespace) {
     if (!this.primaryKey) await this._opening
 
     const keyPair = {
@@ -216,7 +216,7 @@ module.exports = class Corestore extends EventEmitter {
       }
     }
 
-    const seed = deriveSeed(this.primaryKey, this._namespace, name)
+    const seed = deriveSeed(this.primaryKey, namespace, name)
     sodium.crypto_sign_seed_keypair(keyPair.publicKey, keyPair.secretKey, seed)
 
     return keyPair

--- a/test/all.js
+++ b/test/all.js
@@ -168,6 +168,30 @@ test('writable core loaded from name userData', async function (t) {
   t.alike(await core.get(1), Buffer.from('world'))
 })
 
+test('writable core loaded from name and namespace userData', async function (t) {
+  const dir = tmpdir()
+
+  let store = new Corestore(dir)
+  let core = store.namespace('ns1').get({ name: 'main' })
+  await core.ready()
+  const key = core.key
+
+  t.ok(core.writable)
+  await core.append('hello')
+  t.is(core.length, 1)
+
+  await store.close()
+  store = new Corestore(dir)
+  core = store.get(key)
+  await core.ready()
+
+  t.ok(core.writable)
+  await core.append('world')
+  t.is(core.length, 2)
+  t.alike(await core.get(0), Buffer.from('hello'))
+  t.alike(await core.get(1), Buffer.from('world'))
+})
+
 test('storage locking', async function (t) {
   const dir = tmpdir()
 


### PR DESCRIPTION
namespace from userData wasn't being passed to `createKeyPair()`