### PR TITLE
fix(encryption): reopen encrypted cores with correct options

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,13 @@ module.exports = class Corestore extends EventEmitter {
 
     while (this.cores.has(id)) {
       const existing = this.cores.get(id)
-      if (existing.opened && !existing.closing) return { from: existing, keyPair, auth }
+      if (existing.opened && !existing.closing) {
+        if (opts.encryptionKey && !existing.encryptionKey) {
+          await existing.close()
+        } else {
+          return { from: existing, keyPair, auth }
+        }
+      }
       if (!existing.opened) {
         await existing.ready().catch(safetyCatch)
       } else if (existing.closing) {

--- a/test/all.js
+++ b/test/all.js
@@ -311,6 +311,50 @@ test('keypair auth verify', async function (t) {
   t.absent(keyPair.auth.verify(message, b4a.alloc(64)))
 })
 
+test('reopen encrypted core with correct options if it is already opened through replication', async function (t) {
+  // Create an encrypted drive
+  const originStore = new Corestore(tmpdir())
+  const encryptionKey = randomBytes(32)
+  const origin = originStore.get({ name: 'origin', encryptionKey })
+  await origin.ready()
+
+  const originContent = b4a.from(JSON.stringify({ foo: 'bar' }))
+  await origin.append(originContent)
+
+  const coreOpts = {
+    key: origin.key,
+    encryptionKey: origin.encryptionKey
+  }
+
+  t.is(coreOpts.key.length, 32)
+  t.is(coreOpts.encryptionKey, encryptionKey)
+
+  const cloneDir = tmpdir()
+  // Clone to storage then close cloneStore
+  await openClone()
+  // open clone from storage
+  await openClone()
+
+  async function openClone () {
+    const cloneStore = new Corestore(cloneDir)
+    const s = cloneStore.replicate(true)
+    s.pipe(originStore.replicate(false)).pipe(s)
+
+    // Ensure that the clone is opened by discoveryKey (no options)
+    await cloneStore.ready()
+
+    const clone = cloneStore.get(coreOpts)
+    await clone.ready()
+
+    t.is(clone.encryptionKey, encryptionKey, 'encryptionKey is missing')
+
+    const cloneContent = await clone.get(0)
+    t.is(cloneContent.toString(), originContent.toString())
+
+    await cloneStore.close()
+  }
+})
+
 function tmpdir () {
   return path.join(os.tmpdir(), 'corestore-' + Math.random().toString(16).slice(2))
 }


### PR DESCRIPTION
store.replicate() openes cores from storage, where the encryptionKey is
not stored.

 perfect solution might be updating Hypercore-next to store
encryptionKey in Oplog.

 In the meantime this seems a simpler solution.
 
 closes https://github.com/hypercore-protocol/corestore-next/issues/14