### PR TITLE
Close caching infinite loop fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,10 +153,10 @@ module.exports = class Corestore extends EventEmitter {
     while (this.cores.has(id)) {
       const existing = this.cores.get(id)
       if (existing.opened && !existing.closing) return { from: existing, keyPair, auth }
-      if (!existing.opened) {
-        await existing.ready().catch(safetyCatch)
-      } else if (existing.closing) {
+      if (existing.closing) {
         await existing.close()
+      } else {
+        await existing.ready().catch(safetyCatch)
       }
     }
 

--- a/test/all.js
+++ b/test/all.js
@@ -311,6 +311,20 @@ test('keypair auth verify', async function (t) {
   t.absent(keyPair.auth.verify(message, b4a.alloc(64)))
 })
 
+test('core caching after reopen regression', async function (t) {
+  const store = new Corestore(ram)
+  const core = store.get({ name: 'test-core' })
+  await core.ready()
+
+  core.close()
+  await core.opening
+
+  const core2 = store.get({ name: 'test-core' })
+  await core2.ready()
+
+  t.pass('did not infinite loop')
+})
+
 function tmpdir () {
   return path.join(os.tmpdir(), 'corestore-' + Math.random().toString(16).slice(2))
 }


### PR DESCRIPTION
There's a particular condition that can cause Corestore to enter into an infinite loop due to cache handling when a core is is not opened, but is closing.

This fixes that issue and adds a test.