### PR TITLE
validateGetOptions should prioritize key over name

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,6 +342,10 @@ function validateGetOptions (opts) {
     opts.publicKey = opts.keyPair.publicKey
     opts.secretKey = opts.keyPair.secretKey
   }
+  if (opts.publicKey && opts.name) {
+    // The key takes precedence over the name
+    opts.name = null
+  }
   if (opts.name && typeof opts.name !== 'string') throw new Error('name option must be a String')
   if (opts.name && opts.secretKey) throw new Error('Cannot provide both a name and a secret key')
   if (opts.publicKey && !b4a.isBuffer(opts.publicKey)) throw new Error('publicKey option must be a Buffer or Uint8Array')

--- a/test/all.js
+++ b/test/all.js
@@ -323,6 +323,17 @@ test('core caching after reopen regression', async function (t) {
   t.pass('did not infinite loop')
 })
 
+test('when passed both key and name options, the key takes precedence', async function (t) {
+  const store = new Corestore(ram)
+  const core1 = store.get({ name: 'test-core' })
+  await core1.ready()
+
+  const core2 = store.get({ key: core1.key, name: 'test-core-2' })
+  await core2.ready()
+
+  t.alike(core1.key, core2.key)
+})
+
 function tmpdir () {
   return path.join(os.tmpdir(), 'corestore-' + Math.random().toString(16).slice(2))
 }

--- a/test/cache.js
+++ b/test/cache.js
@@ -44,3 +44,12 @@ test('core cache on namespace', async function (t) {
   t.ok(c1.cache)
   t.ok(c2.cache)
 })
+
+test('false cache option does not enable caching', async function (t) {
+  const store = new Corestore(RAM)
+
+  const core = store.get({ name: 'core' })
+  await core.ready()
+
+  t.absent(core.cache)
+})


### PR DESCRIPTION
Currently if you pass both `name` and `key` options to `get`, the `name` will take precedence. If the `key` takes precedence, then patterns like "get or create with name" become doable more easily.